### PR TITLE
Revert "set Go version to 1.15"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ipfs/go-qringbuf
 
-go 1.15
+go 1.11


### PR DESCRIPTION
This reverts commit 394365ee9e30f4874f63db7965e5df7eb7362a3b

I want to use this lib in a more "ancient" setting, hopefully the
automation won't complain...